### PR TITLE
Fix comment typos in Lighthouse LFl section

### DIFF
--- a/Lighthouse.qml
+++ b/Lighthouse.qml
@@ -183,7 +183,7 @@ Item {
 
       if (lightClass === "LFl") {
         let l = 2
-        let d = p - l // TODO might need tweeking for (very) long periodes like 20s
+        let d = p - l // TODO might need tweaking for (very) long periods like 20s
         range(l).forEach(j => { // light parts
           flash.push(1)
         })


### PR DESCRIPTION
## Summary
- fix typos "tweeking" and "periodes" in `Lighthouse.qml` around the `LFl` logic

## Testing
- `grep -n "tweaking" Lighthouse.qml`