### PR TITLE
feat: Add map-based location selector

### DIFF
--- a/AddLocationDialog.qml
+++ b/AddLocationDialog.qml
@@ -111,6 +111,30 @@ Dialog {
                 }
             }
             
+            // Choose on Map button
+            Button {
+                text: "Choose on Map"
+                Layout.fillWidth: true
+                Layout.preferredHeight: 44
+                background: Rectangle {
+                    color: parent.pressed ? "#e3f2fd" : "#2196f3"
+                    border.color: "#1976d2"
+                    border.width: 1
+                    radius: 4
+                }
+                contentItem: Text {
+                    text: parent.text
+                    color: "white"
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                    font.pixelSize: 14
+                    font.bold: true
+                }
+                onClicked: {
+                    mapDialog.open()
+                }
+            }
+            
             // Add some spacing before buttons
             Item {
                 Layout.preferredHeight: 20
@@ -146,6 +170,36 @@ Dialog {
                         root.close()
                     }
                 }
+            }
+        }
+    }
+    
+    // Map selection dialog
+    Dialog {
+        id: mapDialog
+        title: "Choose Location on Map"
+        modal: true
+        parent: root.parent
+        width: root.width
+        height: root.height
+        x: root.x
+        y: root.y
+        
+        MapMode {
+            id: mapMode
+            anchors.fill: parent
+            isSettingHardcodedLocation: true
+            
+            onHardcodedLocationSet: function(lat, lon) {
+                root.latitude = lat
+                root.longitude = lon
+                latField.text = lat.toString()
+                lonField.text = lon.toString()
+                mapDialog.close()
+            }
+            
+            onHardcodedLocationCancelled: function() {
+                mapDialog.close()
             }
         }
     }

--- a/AddLocationDialog.qml
+++ b/AddLocationDialog.qml
@@ -2,6 +2,7 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Window 2.15
+import QtPositioning
 
 Dialog {
     id: root
@@ -178,6 +179,7 @@ Dialog {
     // Map selection dialog
     Dialog {
         id: mapDialog
+        property var initialCenter: QtPositioning.coordinate(0, 0)
         title: "Choose Location on Map"
         modal: true
         parent: root.parent
@@ -185,12 +187,16 @@ Dialog {
         height: root.height
         x: root.x
         y: root.y
+
+        onOpened: {
+            initialCenter = root.selfCoord
+        }
         
         MapLocationSelector {
             id: mapSelector
             anchors.fill: parent
             selfCoord: root.selfCoord
-            center: (root.latitude === 0.0 && root.longitude === 0.0) ? root.selfCoord : QtPositioning.coordinate(root.latitude, root.longitude)
+            center: (root.latitude === 0.0 && root.longitude === 0.0) ? mapDialog.initialCenter : QtPositioning.coordinate(root.latitude, root.longitude)
 
             onHardcodedLocationSet: function(lat, lon) {
                 root.latitude = lat

--- a/AddLocationDialog.qml
+++ b/AddLocationDialog.qml
@@ -9,8 +9,6 @@ Dialog {
     modal: true
     
     // Dynamic positioning and sizing for better mobile support
-    x: Math.max(0, (parent ? parent.width - width : 0) / 2)
-    y: Math.max(20, (parent ? parent.height - height : 0) / 2)
     width: parent ? parent.width * 0.95 : 400
     height: parent ? parent.height * 0.8 : 500
     
@@ -41,6 +39,12 @@ Dialog {
         nameField.text = root.locationName
         latField.text = root.latitude.toString()
         lonField.text = root.longitude.toString()
+        
+        // Ensure proper positioning after dialog is opened
+        if (parent) {
+            x = Math.max(0, (parent.width - width) / 2)
+            y = Math.max(20, (parent.height - height) / 2)
+        }
     }
     
     // Use ScrollView to handle content overflow on small screens

--- a/AddLocationDialog.qml
+++ b/AddLocationDialog.qml
@@ -11,6 +11,8 @@ Dialog {
     // Dynamic positioning and sizing for better mobile support
     width: parent ? parent.width * 0.95 : 400
     height: parent ? parent.height * 0.8 : 500
+    x: parent ? (parent.width - width) / 2 : 0
+    y: parent ? Math.max(20, (parent.height - height) / 2) : 20
     
     // Ensure dialog doesn't go off-screen
     onWidthChanged: {
@@ -39,12 +41,6 @@ Dialog {
         nameField.text = root.locationName
         latField.text = root.latitude.toString()
         lonField.text = root.longitude.toString()
-        
-        // Ensure proper positioning after dialog is opened
-        if (parent) {
-            x = Math.max(0, (parent.width - width) / 2)
-            y = Math.max(20, (parent.height - height) / 2)
-        }
     }
     
     // Use ScrollView to handle content overflow on small screens

--- a/AddLocationDialog.qml
+++ b/AddLocationDialog.qml
@@ -4,6 +4,7 @@ import QtQuick.Layouts 1.15
 import QtQuick.Window 2.15
 
 Dialog {
+    property var selfCoord
     id: root
     title: isEditing ? "Edit Custom Location" : "Add Custom Location"
     modal: true
@@ -185,11 +186,11 @@ Dialog {
         x: root.x
         y: root.y
         
-        MapMode {
-            id: mapMode
+        MapLocationSelector {
+            id: mapSelector
             anchors.fill: parent
-            isSettingHardcodedLocation: true
-            
+            selfCoord: root.selfCoord
+
             onHardcodedLocationSet: function(lat, lon) {
                 root.latitude = lat
                 root.longitude = lon

--- a/AddLocationDialog.qml
+++ b/AddLocationDialog.qml
@@ -46,12 +46,12 @@ Dialog {
     // Use ScrollView to handle content overflow on small screens
     ScrollView {
         anchors.fill: parent
-        anchors.margins: 10
+        anchors.margins: 5
         clip: true
         
         ColumnLayout {
             width: parent.width
-            spacing: 15
+            spacing: 8
             
             Label {
                 text: "Location Name"
@@ -62,7 +62,7 @@ Dialog {
             TextField {
                 id: nameField
                 Layout.fillWidth: true
-                Layout.preferredHeight: 40
+                Layout.preferredHeight: 35
                 placeholderText: "Enter location name"
                 text: root.locationName
                 focus: true
@@ -78,7 +78,7 @@ Dialog {
             TextField {
                 id: latField
                 Layout.fillWidth: true
-                Layout.preferredHeight: 40
+                Layout.preferredHeight: 35
                 placeholderText: "Enter latitude (e.g., 59.901484)"
                 text: root.latitude.toString()
                 inputMethodHints: Qt.ImhFormattedNumbersOnly
@@ -99,7 +99,7 @@ Dialog {
             TextField {
                 id: lonField
                 Layout.fillWidth: true
-                Layout.preferredHeight: 40
+                Layout.preferredHeight: 35
                 placeholderText: "Enter longitude (e.g., 10.751129)"
                 text: root.longitude.toString()
                 inputMethodHints: Qt.ImhFormattedNumbersOnly
@@ -115,7 +115,7 @@ Dialog {
             Button {
                 text: "Choose on Map"
                 Layout.fillWidth: true
-                Layout.preferredHeight: 44
+                Layout.preferredHeight: 38
                 background: Rectangle {
                     color: parent.pressed ? "#e3f2fd" : "#2196f3"
                     border.color: "#1976d2"
@@ -137,27 +137,27 @@ Dialog {
             
             // Add some spacing before buttons
             Item {
-                Layout.preferredHeight: 20
+                Layout.preferredHeight: 10
             }
             
             RowLayout {
                 Layout.fillWidth: true
                 Layout.alignment: Qt.AlignRight
-                spacing: 10
+                spacing: 8
                 
                 Button {
                     text: "Cancel"
                     flat: true // Makes it look like a less prominent action
                     palette.buttonText: "gray"
                     Layout.preferredWidth: 100
-                    Layout.preferredHeight: 40
+                    Layout.preferredHeight: 35
                     onClicked: root.close()
                 }
                 
                 Button {
                     text: isEditing ? "Save" : "Add"
                     Layout.preferredWidth: 100
-                    Layout.preferredHeight: 40
+                    Layout.preferredHeight: 35
                     enabled: nameField.text.trim() !== "" && 
                              !isNaN(root.latitude) &&
                              !isNaN(root.longitude)

--- a/AddLocationDialog.qml
+++ b/AddLocationDialog.qml
@@ -4,8 +4,8 @@ import QtQuick.Layouts 1.15
 import QtQuick.Window 2.15
 
 Dialog {
-    property var selfCoord
     id: root
+    property var selfCoord
     title: isEditing ? "Edit Custom Location" : "Add Custom Location"
     modal: true
     
@@ -190,6 +190,7 @@ Dialog {
             id: mapSelector
             anchors.fill: parent
             selfCoord: root.selfCoord
+            center: (root.latitude === 0.0 && root.longitude === 0.0) ? root.selfCoord : QtPositioning.coordinate(root.latitude, root.longitude)
 
             onHardcodedLocationSet: function(lat, lon) {
                 root.latitude = lat

--- a/MapLocationSelector.qml
+++ b/MapLocationSelector.qml
@@ -23,7 +23,7 @@ import QtQuick.Shapes 1.15
         id: map
         anchors.fill: parent
         plugin: mapPlugin
-        zoomLevel: 14
+        zoomLevel: 10
         copyrightsVisible: false
 
         WheelHandler {
@@ -63,7 +63,7 @@ import QtQuick.Shapes 1.15
                 // The coordinate where the sector is displayed
                 coordinate: modelData.coordinates
                 // Setting zoomLevel makes the item scale with the map
-                zoomLevel: 14
+                zoomLevel: 10
                 anchorPoint.x: sourceItem.width / 2
                 anchorPoint.y: sourceItem.height / 2
 
@@ -94,15 +94,36 @@ import QtQuick.Shapes 1.15
         onActivated: map.zoomLevel = Math.round(map.zoomLevel - 1)
     }
 
-    CompassNeedle {
-        id: compassNeedle
+    SvgButton {
+        id: zoomInButton
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.topMargin: 10
         anchors.leftMargin: 10
-        compassStrokeStyle: ShapePath.SolidLine
-        width: 56
-        height: 56
+        fileName: "qrc:/images/plus-svgrepo-com.svg"
+        MouseArea {
+            anchors.fill: parent
+            onClicked: {
+                map.zoomLevel *= 1.1
+                map.zoomLevel = Math.min(map.zoomLevel, 14)
+            }
+        }
+    }
+
+    SvgButton {
+        id: zoomOutButton
+        anchors.top: zoomInButton.bottom
+        anchors.left: parent.left
+        anchors.topMargin: 10
+        anchors.leftMargin: 10
+        fileName: "qrc:/images/minus-svgrepo-com.svg"
+        MouseArea {
+            anchors.fill: parent
+            onClicked: {
+                map.zoomLevel *= 0.9
+                map.zoomLevel = Math.max(map.zoomLevel, 4)
+            }
+        }
     }
 
     ResetLocationButton {

--- a/MapLocationSelector.qml
+++ b/MapLocationSelector.qml
@@ -127,11 +127,9 @@ import QtQuick.Shapes 1.15
     }
 
     ResetLocationButton {
-        width: 44
-        height: 44
         anchors.top: parent.top
         anchors.right: parent.right
-        anchors.topMargin: 59
+        anchors.topMargin: 64
         anchors.rightMargin: 10
         MouseArea {
             anchors.fill: parent

--- a/MapLocationSelector.qml
+++ b/MapLocationSelector.qml
@@ -1,0 +1,216 @@
+import QtQuick
+import QtQuick.Controls
+import QtLocation
+import QtPositioning
+import QtSensors
+import QtQuick.Shapes 1.15
+
+ Item {
+    id: root
+    property var selfCoord
+    property var nearbyLighthouses
+    property alias center: map.center
+    // flag to indicate if we are animating a reset
+
+    signal hardcodedLocationSet(real latitude, real longitude)
+    signal hardcodedLocationCancelled()
+
+    Plugin {
+        id: mapPlugin
+        name: "osm"
+    }
+
+    Map {
+        id: map
+        anchors.fill: parent
+        plugin: mapPlugin
+        zoomLevel: 14
+        copyrightsVisible: false
+
+        WheelHandler {
+            id: wheel
+            // workaround for QTBUG-87646 / QTBUG-112394 / QTBUG-112432:
+            acceptedDevices: Qt.platform.pluginName === "cocoa" || Qt.platform.pluginName === "wayland"
+                             ? PointerDevice.Mouse | PointerDevice.TouchPad
+                             : PointerDevice.Mouse
+            rotationScale: 1/120
+            property: "zoomLevel"
+        }
+
+        PinchHandler {
+            id: pinch
+            target: null
+
+            onScaleChanged: (delta) => {
+                map.zoomLevel += Math.log2(delta)
+            }
+
+            grabPermissions: PointerHandler.TakeOverForbidden
+        }
+
+        DragHandler {
+            id: drag
+            target: null
+            onTranslationChanged: (delta) => {
+                map.pan(-delta.x, -delta.y)
+            }
+        }
+
+        MapItemView {
+            anchors.fill: parent
+            model: nearbyLighthouses
+
+            delegate: MapQuickItem {
+                // The coordinate where the sector is displayed
+                coordinate: modelData.coordinates
+                // Setting zoomLevel makes the item scale with the map
+                zoomLevel: 14
+                anchorPoint.x: sourceItem.width / 2
+                anchorPoint.y: sourceItem.height / 2
+
+                sourceItem: RenderableSectors {
+                    width: 50
+                    height: 50
+                    sectors: modelData.sectors
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: {
+                            infoBox.lighthouse = modelData
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Shortcut {
+        enabled: map.zoomLevel < map.maximumZoomLevel
+        sequence: StandardKey.ZoomIn
+        onActivated: map.zoomLevel = Math.round(map.zoomLevel + 1)
+    }
+
+    Shortcut {
+        enabled: map.zoomLevel > map.minimumZoomLevel
+        sequence: StandardKey.ZoomOut
+        onActivated: map.zoomLevel = Math.round(map.zoomLevel - 1)
+    }
+
+    CompassNeedle {
+        id: compassNeedle
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.topMargin: 10
+        anchors.leftMargin: 10
+        compassStrokeStyle: ShapePath.SolidLine
+        width: 56
+        height: 56
+    }
+
+    ResetLocationButton {
+        width: 44
+        height: 44
+        anchors.top: parent.top
+        anchors.right: parent.right
+        anchors.topMargin: 59
+        anchors.rightMargin: 10
+        MouseArea {
+            anchors.fill: parent
+            onClicked: {
+                map.center = selfCoord
+            }
+        }
+    }
+
+    // Center crosshair lines when setting hardcoded location
+    Rectangle {
+        id: verticalLine
+        width: 1
+        height: parent.height
+        color: "red"
+        opacity: 0.7
+        anchors.horizontalCenter: parent.horizontalCenter
+    }
+
+    Rectangle {
+        id: horizontalLine
+        width: parent.width
+        height: 1
+        color: "red"
+        opacity: 0.7
+        anchors.verticalCenter: parent.verticalCenter
+    }
+
+    // Coordinates display at the top right (where settings button normally is)
+    Rectangle {
+        id: coordinatesBox
+        width: parent.width / 2 - 20
+        height: 44
+        color: "black"
+        opacity: 0.8
+        radius: 5
+        anchors.top: parent.top
+        anchors.right: parent.right
+        anchors.topMargin: 10
+        anchors.rightMargin: 10
+
+        Column {
+            anchors.left: parent.left
+            anchors.leftMargin: 8
+            anchors.verticalCenter: parent.verticalCenter
+            spacing: 1
+
+            Text {
+                id: latText
+                color: "white"
+                font.pixelSize: 12
+                text: "Latitude: " + map.center.latitude.toFixed(3)
+            }
+
+            Text {
+                id: lonText
+                color: "white"
+                font.pixelSize: 12
+                text: "Longitude: " + map.center.longitude.toFixed(3)
+            }
+        }
+    }
+
+    Button {
+        text: "Add"
+        width: 80
+        height: 44
+        anchors.bottom: parent.bottom
+        anchors.right: parent.right
+        anchors.bottomMargin: 20
+        anchors.rightMargin: 20
+        onClicked: {
+            hardcodedLocationSet(map.center.latitude, map.center.longitude)
+        }
+    }
+
+    Button {
+        text: "Cancel"
+        width: 80
+        height: 44
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.bottomMargin: 20
+        anchors.leftMargin: 20
+        background: Rectangle {
+            color: parent.pressed ? "#e3f2fd" : "white"
+            border.color: "#2196f3"
+            border.width: 1
+            radius: 4
+        }
+        contentItem: Text {
+            text: parent.text
+            color: "#2196f3"
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+            font.pixelSize: 14
+        }
+        onClicked: {
+            hardcodedLocationCancelled()
+        }
+    }
+}

--- a/MapLocationSelector.qml
+++ b/MapLocationSelector.qml
@@ -10,7 +10,6 @@ import QtQuick.Shapes 1.15
     property var selfCoord
     property var nearbyLighthouses
     property alias center: map.center
-    // flag to indicate if we are animating a reset
 
     signal hardcodedLocationSet(real latitude, real longitude)
     signal hardcodedLocationCancelled()

--- a/MapMode.qml
+++ b/MapMode.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import QtQuick.Controls
 import QtLocation
 import QtPositioning
 import QtSensors
@@ -18,6 +19,10 @@ Item {
     property bool customRotation: false
     property bool customScale: false
     property bool customCenter: false
+    property bool isSettingHardcodedLocation: false
+
+    signal hardcodedLocationSet(real latitude, real longitude)
+    signal hardcodedLocationCancelled()
 
     // activeBearing uses the animated value when animating, otherwise uses
     // either map.bearing (if customRotation) or the compass value.
@@ -175,7 +180,7 @@ Item {
         compassStrokeStyle: (customRotation) ? ShapePath.DashLine : ShapePath.SolidLine
         width: 56
         height: 56
-        // while animating, use the map’s current bearing
+        // while animating, use the map's current bearing
         rotation: -activeBearing
 
         MouseArea {
@@ -220,6 +225,104 @@ Item {
             onClicked: {
                 infoBox.lighthouse = null
             }
+        }
+    }
+
+    // Center crosshair lines when setting hardcoded location
+    Rectangle {
+        id: verticalLine
+        visible: isSettingHardcodedLocation
+        width: 1
+        height: parent.height
+        color: "red"
+        opacity: 0.7
+        anchors.horizontalCenter: parent.horizontalCenter
+    }
+
+    Rectangle {
+        id: horizontalLine
+        visible: isSettingHardcodedLocation
+        width: parent.width
+        height: 1
+        color: "red"
+        opacity: 0.7
+        anchors.verticalCenter: parent.verticalCenter
+    }
+
+    // Coordinates display at the top right (where settings button normally is)
+    Rectangle {
+        id: coordinatesBox
+        visible: isSettingHardcodedLocation
+        width: parent.width / 2 - 20
+        height: 44
+        color: "black"
+        opacity: 0.8
+        radius: 5
+        anchors.top: parent.top
+        anchors.right: parent.right
+        anchors.topMargin: 10
+        anchors.rightMargin: 10
+
+        Column {
+            anchors.left: parent.left
+            anchors.leftMargin: 8
+            anchors.verticalCenter: parent.verticalCenter
+            spacing: 1
+
+            Text {
+                id: latText
+                color: "white"
+                font.pixelSize: 12
+                text: isSettingHardcodedLocation ? "Latitude: " + map.center.latitude.toFixed(3) : ""
+            }
+
+            Text {
+                id: lonText
+                color: "white"
+                font.pixelSize: 12
+                text: isSettingHardcodedLocation ? "Longitude: " + map.center.longitude.toFixed(3) : ""
+            }
+        }
+    }
+
+    Button {
+        text: "Add"
+        visible: isSettingHardcodedLocation
+        width: 80
+        height: 44
+        anchors.bottom: parent.bottom
+        anchors.right: parent.right
+        anchors.bottomMargin: 20
+        anchors.rightMargin: 20
+        onClicked: {
+            hardcodedLocationSet(map.center.latitude, map.center.longitude)
+        }
+    }
+
+    Button {
+        text: "Cancel"
+        visible: isSettingHardcodedLocation
+        width: 80
+        height: 44
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.bottomMargin: 20
+        anchors.leftMargin: 20
+        background: Rectangle {
+            color: parent.pressed ? "#e3f2fd" : "white"
+            border.color: "#2196f3"
+            border.width: 1
+            radius: 4
+        }
+        contentItem: Text {
+            text: parent.text
+            color: "#2196f3"
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+            font.pixelSize: 14
+        }
+        onClicked: {
+            hardcodedLocationCancelled()
         }
     }
 }

--- a/MapMode.qml
+++ b/MapMode.qml
@@ -200,6 +200,7 @@ Item {
         anchors.right: parent.right
         anchors.topMargin: 59
         anchors.rightMargin: 10
+        arrowStyleOpen: customCenter
         MouseArea {
             anchors.fill: parent
             onClicked: {

--- a/MapMode.qml
+++ b/MapMode.qml
@@ -19,7 +19,6 @@ Item {
     property bool customRotation: false
     property bool customScale: false
     property bool customCenter: false
-    property bool isSettingHardcodedLocation: false
 
     signal hardcodedLocationSet(real latitude, real longitude)
     signal hardcodedLocationCancelled()
@@ -226,104 +225,6 @@ Item {
             onClicked: {
                 infoBox.lighthouse = null
             }
-        }
-    }
-
-    // Center crosshair lines when setting hardcoded location
-    Rectangle {
-        id: verticalLine
-        visible: isSettingHardcodedLocation
-        width: 1
-        height: parent.height
-        color: "red"
-        opacity: 0.7
-        anchors.horizontalCenter: parent.horizontalCenter
-    }
-
-    Rectangle {
-        id: horizontalLine
-        visible: isSettingHardcodedLocation
-        width: parent.width
-        height: 1
-        color: "red"
-        opacity: 0.7
-        anchors.verticalCenter: parent.verticalCenter
-    }
-
-    // Coordinates display at the top right (where settings button normally is)
-    Rectangle {
-        id: coordinatesBox
-        visible: isSettingHardcodedLocation
-        width: parent.width / 2 - 20
-        height: 44
-        color: "black"
-        opacity: 0.8
-        radius: 5
-        anchors.top: parent.top
-        anchors.right: parent.right
-        anchors.topMargin: 10
-        anchors.rightMargin: 10
-
-        Column {
-            anchors.left: parent.left
-            anchors.leftMargin: 8
-            anchors.verticalCenter: parent.verticalCenter
-            spacing: 1
-
-            Text {
-                id: latText
-                color: "white"
-                font.pixelSize: 12
-                text: isSettingHardcodedLocation ? "Latitude: " + map.center.latitude.toFixed(3) : ""
-            }
-
-            Text {
-                id: lonText
-                color: "white"
-                font.pixelSize: 12
-                text: isSettingHardcodedLocation ? "Longitude: " + map.center.longitude.toFixed(3) : ""
-            }
-        }
-    }
-
-    Button {
-        text: "Add"
-        visible: isSettingHardcodedLocation
-        width: 80
-        height: 44
-        anchors.bottom: parent.bottom
-        anchors.right: parent.right
-        anchors.bottomMargin: 20
-        anchors.rightMargin: 20
-        onClicked: {
-            hardcodedLocationSet(map.center.latitude, map.center.longitude)
-        }
-    }
-
-    Button {
-        text: "Cancel"
-        visible: isSettingHardcodedLocation
-        width: 80
-        height: 44
-        anchors.bottom: parent.bottom
-        anchors.left: parent.left
-        anchors.bottomMargin: 20
-        anchors.leftMargin: 20
-        background: Rectangle {
-            color: parent.pressed ? "#e3f2fd" : "white"
-            border.color: "#2196f3"
-            border.width: 1
-            radius: 4
-        }
-        contentItem: Text {
-            text: parent.text
-            color: "#2196f3"
-            horizontalAlignment: Text.AlignHCenter
-            verticalAlignment: Text.AlignVCenter
-            font.pixelSize: 14
-        }
-        onClicked: {
-            hardcodedLocationCancelled()
         }
     }
 }

--- a/ResetLocationButton.qml
+++ b/ResetLocationButton.qml
@@ -5,6 +5,8 @@ import QtQuick.Shapes 1.15
 Rectangle {
     id: root
     radius: 5
+    width: 44
+    height: 44
     color: Qt.rgba(1.0, 1.0, 1.0, 0.0)
     border.color: "#000"
     border.width: 2

--- a/ResetLocationButton.qml
+++ b/ResetLocationButton.qml
@@ -8,6 +8,7 @@ Rectangle {
     color: Qt.rgba(1.0, 1.0, 1.0, 0.0)
     border.color: "#000"
     border.width: 2
+    property bool arrowStyleOpen
 
     readonly property string arrowFilledFileName: "qrc:/images/location-arrow-svgrepo-com.svg"
     readonly property string arrowOpenFileName: "qrc:/images/location-arrow-o-svgrepo-com.svg"
@@ -15,7 +16,7 @@ Rectangle {
 
     Image {
         id: image
-        source: customCenter ? arrowOpenFileName : arrowFilledFileName
+        source: arrowStyleOpen ? arrowOpenFileName : arrowFilledFileName
         x: parent.width / 2 - image.width / 2 - 1
         y: parent.height / 2 - image.height / 2 + 1
         width: customScale ? 15 : 23

--- a/SettingsView.qml
+++ b/SettingsView.qml
@@ -12,6 +12,7 @@ Page {
     property real hardcodedLongitude
     property real hardcodedLatitude
     property real selfHeight: 2.0
+    property var selfCoord
 
     // Settings for persistent storage
     Settings {
@@ -315,6 +316,7 @@ Page {
     // Add Location Dialog
     AddLocationDialog {
         id: addLocationDialog
+        selfCoord: root.selfCoord
         onLocationAdded: function(name, lat, lon) {
             addCustomLocation(name, lat, lon)
         }

--- a/SvgButton.qml
+++ b/SvgButton.qml
@@ -1,0 +1,24 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Shapes 1.15
+
+Rectangle {
+    id: root
+    width: 44
+    height: 44
+    radius: 5
+    color: Qt.rgba(1.0, 1.0, 1.0, 0.0)
+    border.color: "#000"
+    border.width: 2
+    property var fileName
+
+    Image {
+        id: image
+        source: fileName
+        anchors.fill: parent
+        x: parent.width / 2 - image.width / 2 - 1
+        y: parent.height / 2 - image.height / 2 + 1
+    }
+}
+
+

--- a/images/minus-svgrepo-com.svg
+++ b/images/minus-svgrepo-com.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6 12L18 12" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/images/plus-svgrepo-com.svg
+++ b/images/plus-svgrepo-com.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6 12H18M12 6V18" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/main.qml
+++ b/main.qml
@@ -43,6 +43,7 @@ Window {
 
     SettingsView {
         id: settings
+        selfCoord: root.selfCoord
 
         function updateSelfCoord() {
             if (useHardCodedPosition) {

--- a/qml.qrc
+++ b/qml.qrc
@@ -178,5 +178,6 @@
         <file>images/location-arrow-o-svgrepo-com.svg</file>
         <file>images/location-arrow-svgrepo-com.svg</file>
         <file>Lighthouse.qml</file>
+        <file>MapLocationSelector.qml</file>
     </qresource>
 </RCC>

--- a/qml.qrc
+++ b/qml.qrc
@@ -179,5 +179,8 @@
         <file>images/location-arrow-svgrepo-com.svg</file>
         <file>Lighthouse.qml</file>
         <file>MapLocationSelector.qml</file>
+        <file>SvgButton.qml</file>
+        <file>images/minus-svgrepo-com.svg</file>
+        <file>images/plus-svgrepo-com.svg</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
This pull request introduces a new feature that allows users to select a custom location from a map.

**Changes:**

*   Added a "Choose on Map" button to the "Add Custom Location" dialog.
*   Created a new `MapLocationSelector` component that displays a map and allows users to select a location.
*   The selected latitude and longitude are automatically filled into the form.
*   Added new SVG icons for zoom buttons.
*   Created a reusable `SvgButton` component.

This improves the user experience by making it easier to add custom locations without having to manually enter coordinates.